### PR TITLE
fix: migrate 'semver' module to std

### DIFF
--- a/src/components/manifest.ts
+++ b/src/components/manifest.ts
@@ -1,5 +1,5 @@
-import type { ReleaseType } from "https://deno.land/x/semver/mod.ts";
-import { inc } from "https://deno.land/x/semver/mod.ts";
+import type { ReleaseType } from "https://deno.land/std/semver/mod.ts";
+import { inc } from "https://deno.land/std/semver/mod.ts";
 import { join } from "https://deno.land/std@0.123.0/path/mod.ts";
 import {
   BP_MODULE_UUID,


### PR DESCRIPTION
The 'semver' module has been migrated to the standard library https://deno.land/std/semver